### PR TITLE
Remove limit from requests/responses

### DIFF
--- a/src/IDispatcher.sol
+++ b/src/IDispatcher.sol
@@ -14,8 +14,6 @@ struct DispatchPost {
     bytes body;
     // timeout for this request in seconds
     uint64 timeout;
-    // gas limit for executing this request on destination & its response (if any) on the source.
-    uint64 gaslimit;
     // the amount put up to be paid to the relayer, this is in $DAI and charged to tx.origin
     uint256 fee;
     // who pays for this request?
@@ -32,8 +30,6 @@ struct DispatchGet {
     bytes[] keys;
     // timeout for this request in seconds
     uint64 timeout;
-    // gas limit for executing this request on destination & its response (if any) on the source.
-    uint64 gaslimit;
     // the amount put up to be paid to the relayer, this is in $DAI and charged to tx.origin
     uint256 fee;
     // who pays for this request?
@@ -47,8 +43,6 @@ struct DispatchPostResponse {
     bytes response;
     // timeout for this response in seconds
     uint64 timeout;
-    // gas limit for executing this response on destination which is the source of the request.
-    uint64 gaslimit;
     // the amount put up to be paid to the relayer, this is in $DAI and charged to tx.origin
     uint256 fee;
     // who pays for this request?

--- a/src/Message.sol
+++ b/src/Message.sol
@@ -19,8 +19,6 @@ struct PostRequest {
     uint64 timeoutTimestamp;
     // request body
     bytes body;
-    // gas limit for executing this request on destination & its response (if any) on the source.
-    uint64 gaslimit;
 }
 
 struct GetRequest {
@@ -38,8 +36,6 @@ struct GetRequest {
     bytes[] keys;
     // height at which to read destination state machine
     uint64 height;
-    // gas limit for executing this request on destination
-    uint64 gaslimit;
 }
 
 struct GetResponse {
@@ -56,8 +52,6 @@ struct PostResponse {
     bytes response;
     // timestamp by which this response times out.
     uint64 timeoutTimestamp;
-    // gas limit for executing this response on destination which is the source of the request.
-    uint64 gaslimit;
 }
 
 // A post request as a leaf in a merkle tree
@@ -170,13 +164,13 @@ library Message {
 
     function encodeRequest(PostRequest memory req) internal pure returns (bytes memory) {
         return abi.encodePacked(
-            req.source, req.dest, req.nonce, req.timeoutTimestamp, req.from, req.to, req.body, req.gaslimit
+            req.source, req.dest, req.nonce, req.timeoutTimestamp, req.from, req.to, req.body
         );
     }
 
     function hash(PostResponse memory res) internal pure returns (bytes32) {
         return keccak256(
-            bytes.concat(encodeRequest(res.request), abi.encodePacked(res.response, res.timeoutTimestamp, res.gaslimit))
+            bytes.concat(encodeRequest(res.request), abi.encodePacked(res.response, res.timeoutTimestamp))
         );
     }
 
@@ -193,7 +187,7 @@ library Message {
 
         return keccak256(
             abi.encodePacked(
-                req.source, req.dest, req.nonce, req.height, req.timeoutTimestamp, req.from, keysEncoding, req.gaslimit
+                req.source, req.dest, req.nonce, req.height, req.timeoutTimestamp, req.from, keysEncoding
             )
         );
     }


### PR DESCRIPTION
Since requests are paid for ahead of time, they're not useful